### PR TITLE
Reduce the number of permutations in the test matrix

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -50,9 +50,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12, ubuntu-20.04] # Operating systems
+        os: [ubuntu-20.04] # Operating systems
         compiler: [8] # GNU compiler version
-        py_v: [3.8, 3.9, '3.10'] # Python versions
+        py_v: [3.9] # Python versions
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The SmartDashboard repo is currently private which means that we are charged for the Gitlab minutes. To ensure that we can continue testing, this test reduces the number of permutations to just the Ubuntu image and testing with Python 3.9. Once the repo goes public this should be changed back to the full test matrix that SmartSim uses.