### PR TITLE
SmartDashboard #15: local_css() doesn't handle file not found condition

### DIFF
--- a/smartdashboard/utils/pageSetup.py
+++ b/smartdashboard/utils/pageSetup.py
@@ -35,8 +35,11 @@ def local_css(file_name: str) -> None:
     :param file_name: CSS file
     :type file_name: str
     """
-    with open(file_name, encoding="utf-8") as file:
-        st.markdown(f"<style>{file.read()}</style>", unsafe_allow_html=True)
+    try:
+        with open(file_name, encoding="utf-8") as file:
+            st.markdown(f"<style>{file.read()}</style>", unsafe_allow_html=True)
+    except FileNotFoundError:
+        print("CSS file not found. Certain elements in the page will not be styled.")
 
 
 def set_streamlit_page_config() -> None:


### PR DESCRIPTION
Added a `try/except` block to catch a `FileNotFoundError` if the css file cannot be found. The page will now load and work normally with a few elements that are not styled.