### PR TITLE
whitespace needed for markdown newline

### DIFF
--- a/smartdashboard/view_builders.py
+++ b/smartdashboard/view_builders.py
@@ -69,7 +69,7 @@ def error_builder(error: SSDashboardError) -> ErrorView:
     view = ErrorView()
     st.header(str(error))
     st.error(
-        f"""Error found in file: {error.file}
+        f"""Error found in file: {error.file}  
              Error Message: {error.exception}"""
     )
 


### PR DESCRIPTION
I took out a bunch of unnecessary whitespace, but this one is necessary! It's a newline in the markdown that gets rendered in the message when there's an error.