### PR TITLE
Refactor view_builders

### DIFF
--- a/smartdashboard/utils/helpers.py
+++ b/smartdashboard/utils/helpers.py
@@ -384,3 +384,15 @@ def get_shard(
             return shard
 
     return None
+
+
+def shard_log_spacing() -> None:
+    """Adds the necessary spacing to the
+    error logs so they are even with the
+    output logs for shards.
+    """
+    st.write("#")
+    st.write("")
+    st.write("")
+    st.write("")
+    st.write("")

--- a/smartdashboard/view_builders.py
+++ b/smartdashboard/view_builders.py
@@ -47,6 +47,7 @@ from smartdashboard.utils.helpers import (
     get_shard,
     get_value,
     render_dataframe,
+    shard_log_spacing,
 )
 from smartdashboard.utils.ManifestReader import Manifest
 from smartdashboard.views import (
@@ -268,11 +269,7 @@ def orc_builder(manifest: Manifest) -> OrchestratorView:
             view.out_logs_element = st.code(view.out_logs, language=None)
 
         with col2:
-            st.write("#")
-            st.write("")
-            st.write("")
-            st.write("")
-            st.write("")
+            shard_log_spacing()
             st.write("Error")
             view.err_logs_element = st.code(view.err_logs, language=None)
 


### PR DESCRIPTION
In this PR I added `build_dataframe_generic` and `build_dataframe_loaded_entities` (I could use help on naming!)
I separated them because they do not build dataframes in the same way. I am hesitant to try to get this in before code freeze because it does touch a lot of the rendering dashboard code.