### PR TITLE
[no merge] Adding schemas for entity objects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ classifiers = [
 readme = "README.md"
 dependencies = [
     "pandas>=2.0.0",
+    "pydantic>=2.5.2",
     "streamlit>=1.27.1",
     "watchdog>=3.0.0",
 ]


### PR DESCRIPTION
Previously all entities had the type Dict[str, Any]. I've added Application, Shard, Orchestrator, Ensemble, Run, and Experiment schemas so that they can be properly validated and statically type checked.

These changes are considered high risk because we are close to release, so this should not be merged until after the release!