### PR TITLE
Add __main__ for a single point of entry to build the dashboard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ doc = [
 
 
 [project.scripts]
-smart-dash = "smartdashboard.Experiment_Overview:cli"
+smart-dash = "smartdashboard.__main__:main"
 
 
 [tool.setuptools]

--- a/smartdashboard/__main__.py
+++ b/smartdashboard/__main__.py
@@ -1,0 +1,36 @@
+# BSD 2-Clause License
+#
+# Copyright (c) 2021-2023, Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import smartdashboard.Experiment_Overview
+
+
+def main() -> int:
+    smartdashboard.Experiment_Overview.cli()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
There was an issue with the `smart` cli where running `smart dashboard` with arguments wasn't calling the correct `cli` function in the dashboard repo in order to build itself, however, `smart-dash` was working perfectly fine. It turns out that calling `smart dashboard` was invoking the `execute` function and entirely bypassing the `cli` function which actually runs streamlit with the correct arguments attached.

Note: If this is approved, there will need to be a slight change made to the SmartSim repo as well. In `plugin.py` when calling `dynamic_execute`, the first parameter should be changed to `"smartdashboard"`

Another note: credit goes to Toast