### PR TITLE
Update version and allow backwards compatibility

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -22,7 +22,7 @@ copyright = '2021-2024, Hewlett Packard Enterprise'
 author = 'Hewlett Packard Enterprise'
 
 # The full version, including alpha/beta/rc tags
-version = "0.0.2"
+version = "0.0.3"
 
 # The full version, including alpha/beta/rc tags
 release = version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ readme = "README.md"
 dependencies = [
     "pandas>=2.0.0",
     "pydantic>=2.5.2",
-    "streamlit>=1.27.1",
+    "streamlit>=1.28.0",
     "watchdog>=3.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smartdashboard"
-version = "0.0.2"
+version = "0.0.3"
 requires-python = ">=3.8,<3.11"
 authors = [
   {name = "CrayLabs: a Hewlett Packard Enterprise OSS Organization", email = "craylabs@hpe.com"},

--- a/smartdashboard/Experiment_Overview.py
+++ b/smartdashboard/Experiment_Overview.py
@@ -49,7 +49,7 @@ def build_app(manifest_path: str) -> None:
 
     curr_path = pathlib.Path(os.path.abspath(__file__)).parent
     local_css(str(curr_path / "static/style.css"))
-    manifest_path="/Users/alyssacote/smartsim/SmartDashboard/tests/utils/manifest_files/0.0.2_manifest.json"
+
     try:
         manifest = load_manifest(manifest_path)
     except SSDashboardError as ex:

--- a/smartdashboard/Experiment_Overview.py
+++ b/smartdashboard/Experiment_Overview.py
@@ -49,7 +49,7 @@ def build_app(manifest_path: str) -> None:
 
     curr_path = pathlib.Path(os.path.abspath(__file__)).parent
     local_css(str(curr_path / "static/style.css"))
-
+    manifest_path="/Users/alyssacote/smartsim/SmartDashboard/tests/utils/manifest_files/0.0.2_manifest.json"
     try:
         manifest = load_manifest(manifest_path)
     except SSDashboardError as ex:

--- a/smartdashboard/schemas/base.py
+++ b/smartdashboard/schemas/base.py
@@ -34,8 +34,8 @@ class HasName(BaseModel):
 
 
 class HasOutErrFiles(BaseModel):
-    out_file: str
-    err_file: str
+    out_file: str = ""
+    err_file: str = ""
 
 
 class HasTelemetryMetaData(BaseModel):

--- a/smartdashboard/static/style.css
+++ b/smartdashboard/static/style.css
@@ -25,7 +25,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
 
 /* change font of expander label */
-div[data-testid="stExpander"] div[role="button"] p {
+div[data-testid="stExpander"] details summary p {
     font-family: "Source Sans Pro", sans-serif;
     font-weight: 600;
     color: var(--primary-text-color);

--- a/smartdashboard/utils/ManifestReader.py
+++ b/smartdashboard/utils/ManifestReader.py
@@ -99,7 +99,7 @@ class ManifestFileReader(ManifestReader):
                 "Version data is malformed.", file=self._file_path, exception=key
             ) from key
 
-        if version not in ('0.0.2', '0.0.3'):
+        if version not in ("0.0.2", "0.0.3"):
             version_exception = Exception(
                 "SmartDashboard version 0.0.3 is unable to parse manifest "
                 f"file at version {version}."

--- a/smartdashboard/utils/ManifestReader.py
+++ b/smartdashboard/utils/ManifestReader.py
@@ -99,9 +99,9 @@ class ManifestFileReader(ManifestReader):
                 "Version data is malformed.", file=self._file_path, exception=key
             ) from key
 
-        if version != "0.0.2":
+        if version not in ('0.0.2', '0.0.3'):
             version_exception = Exception(
-                "SmartDashboard version 0.0.2 is unable to parse manifest "
+                "SmartDashboard version 0.0.3 is unable to parse manifest "
                 f"file at version {version}."
             )
             raise VersionIncompatibilityError(

--- a/smartdashboard/view_builders.py
+++ b/smartdashboard/view_builders.py
@@ -87,7 +87,7 @@ def exp_builder(manifest: Manifest) -> ExperimentView:
     st.write("Path: " + manifest.experiment.path)
     st.write("Launcher: " + manifest.experiment.launcher)
 
-    with st.expander(label="Logs"):
+    with st.expander(label="Logs", expanded=True):
         col1, col2 = st.columns([6, 6])
         with col1:
             st.write("Output")

--- a/smartdashboard/views.py
+++ b/smartdashboard/views.py
@@ -313,8 +313,7 @@ class ErrorView(ViewBase):
     information.
     """
 
-    def update(self) -> None:
-        ...
+    def update(self) -> None: ...
 
 
 class OverviewView:

--- a/tests/test_ManifestReader/test_manifestfilereader_get_manifest.py
+++ b/tests/test_ManifestReader/test_manifestfilereader_get_manifest.py
@@ -69,6 +69,14 @@ from smartdashboard.utils.ManifestReader import Manifest, ManifestFileReader
             0,
             Manifest,
         ),
+        pytest.param(
+            "tests/utils/manifest_files/0.0.2_manifest.json",
+            2,
+            4,
+            3,
+            3,
+            Manifest,
+        ),
     ],
 )
 def test_get_manifest(

--- a/tests/test_ManifestReader/test_manifestfilereader_load_manifest.py
+++ b/tests/test_ManifestReader/test_manifestfilereader_load_manifest.py
@@ -34,6 +34,7 @@ from smartdashboard.utils.ManifestReader import Manifest, load_manifest
     "json_file, result_type",
     [
         pytest.param("tests/utils/manifest_files/manifesttest.json", Manifest),
+        pytest.param("tests/utils/manifest_files/0.0.2_manifest.json", Manifest),
         pytest.param("tests/utils/manifest_files/no_apps_manifest.json", Manifest),
         pytest.param("file_doesn't_exist.json", ManifestError),
         pytest.param("tests/utils/manifest_files/JSONDecodererror.json", ManifestError),

--- a/tests/utils/manifest_files/0.0.2_manifest.json
+++ b/tests/utils/manifest_files/0.0.2_manifest.json
@@ -1,0 +1,797 @@
+{
+    "schema info": {
+        "schema_name": "entity manifest",
+        "version": "0.0.2"
+    },
+    "experiment": {
+        "name": "my-experiment",
+        "path": "experiment/path",
+        "launcher": "local"
+    },
+    "runs": [
+        {
+            "run_id": "1",
+            "model": [
+                {
+                    "name": "app1",
+                    "path": "app/1/path",
+                    "exe_args": [
+                        "string"
+                    ],
+                    "batch_settings": {
+                        "batch_cmd": "command",
+                        "batch_args": {
+                            "arg1": "string1",
+                            "arg2": null
+                        }
+                    },
+                    "run_settings": {
+                        "exe": "echo",
+                        "run_command": "srun",
+                        "run_args": {
+                            "arg1": "string1",
+                            "arg2": null
+                        }
+                    },
+                    "params": {
+                        "param": "param value"
+                    },
+                    "files": {
+                        "Symlink": [
+                            "file1",
+                            "file2"
+                        ],
+                        "Configure": [
+                            "file3"
+                        ],
+                        "Copy": [
+                            "file4",
+                            "file5"
+                        ]
+                    },
+                    "colocated_db": {
+                        "settings": {
+                            "protocol": "TCP/IP",
+                            "port": 1111,
+                            "interface": "lo",
+                            "db_cpus": 1,
+                            "limit_app_cpus": "True",
+                            "debug": "False"
+                        },
+                        "scripts": [
+                            {
+                                "script1": {
+                                    "backend": "script1_torch",
+                                    "device": "script1_cpu"
+                                }
+                            },
+                            {
+                                "script2": {
+                                    "backend": "script2_torch",
+                                    "device": "script2_gpu"
+                                }
+                            }
+                        ],
+                        "models": [
+                            {
+                                "model1": {
+                                    "backend": "model1_tf",
+                                    "device": "model1_cpu"
+                                }
+                            },
+                            {
+                                "model2": {
+                                    "backend": "model2_tf",
+                                    "device": "model2_cpu"
+                                }
+                            }
+                        ]
+                    },
+                    "telemetry_metadata": {
+                        "status_dir": "tests/utils/status_files/model_0",
+                        "job_id": "111",
+                        "step_id": "111"
+                    },
+                    "out_file": "tests/utils/log_files/model_0.out",
+                    "err_file": "tests/utils/log_files/model_0.err"
+                },
+                {
+                    "name": "app2",
+                    "path": "app/2/path",
+                    "exe_args": [
+                        "string1",
+                        "string2",
+                        "string3"
+                    ],
+                    "batch_settings": {
+                        "batch_cmd": "command",
+                        "batch_args": {
+                            "arg1": "string1",
+                            "arg2": null
+                        }
+                    },
+                    "run_settings": {
+                        "exe": "echo",
+                        "run_command": "srun",
+                        "run_args": {
+                            "arg1": "string1",
+                            "arg2": null
+                        }
+                    },
+                    "params": {
+                        "string": [
+                            "Any"
+                        ]
+                    },
+                    "files": {
+                        "Symlink": [
+                            "file1",
+                            "file2"
+                        ],
+                        "Configure": [
+                            "file3"
+                        ],
+                        "Copy": [
+                            "file4",
+                            "file5"
+                        ]
+                    },
+                    "colocated_db": {
+                        "settings": {
+                            "protocol": "TCP/IP",
+                            "port": 1111,
+                            "interface": "lo",
+                            "db_cpus": 1,
+                            "limit_app_cpus": "True",
+                            "debug": "False"
+                        },
+                        "scripts": [
+                            {
+                                "script1": {
+                                    "backend": "script1_torch",
+                                    "device": "script1_cpu"
+                                }
+                            },
+                            {
+                                "script2": {
+                                    "backend": "script2_torch",
+                                    "device": "script2_gpu"
+                                }
+                            }
+                        ],
+                        "models": [
+                            {
+                                "model1": {
+                                    "backend": "model1_tf",
+                                    "device": "model1_cpu"
+                                }
+                            },
+                            {
+                                "model2": {
+                                    "backend": "model2_tf",
+                                    "device": "model2_cpu"
+                                }
+                            }
+                        ]
+                    },
+                    "telemetry_metadata": {
+                        "status_dir": "tests/utils/status_files/model_1",
+                        "job_id": "111",
+                        "step_id": "111"
+                    },
+                    "out_file": "tests/utils/log_files/model_1.out",
+                    "err_file": "tests/utils/log_files/model_1.err"
+                }
+            ],
+            "orchestrator": [
+                {
+                    "name": "orchestrator_1",
+                    "type": "redis",
+                    "interface": [
+                        "lo",
+                        "lo2"
+                    ],
+                    "shards": [
+                        {
+                            "name": "shard 1",
+                            "hostname": "shard1_host",
+                            "port": "11111",
+                            "out_file": "tests/utils/log_files/model_1.out",
+                            "err_file": "tests/utils/log_files/model_1.err",
+                            "conf_file": "/path/to/conf_file",
+                            "telemetry_metadata": {
+                                "status_dir": "tests/utils/status_files/model_3",
+                                "job_id": "111",
+                                "step_id": "111"
+                            }
+                        },
+                        {
+                            "name": "shard 2",
+                            "hostname": "shard2_host",
+                            "port": "11111",
+                            "out_file": "tests/utils/log_files/model_0.out",
+                            "err_file": "tests/utils/log_files/model_0.err",
+                            "conf_file": "/path/to/conf_file",
+                            "telemetry_metadata": {
+                                "status_dir": "tests/utils/status_files/model_1",
+                                "job_id": "111",
+                                "step_id": "111"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "ensemble": [
+                {
+                    "name": "ensemble_1",
+                    "perm_strat": "string0",
+                    "batch_settings": {
+                        "string": "Any0"
+                    },
+                    "params": {
+                        "string": [
+                            "Any1",
+                            "Any3"
+                        ]
+                    },
+                    "models": [
+                        {
+                            "name": "ensemble_1_member_1",
+                            "path": "string",
+                            "exe_args": [
+                                "string"
+                            ],
+                            "batch_settings": {
+                                "batch_cmd": "command",
+                                "batch_args": {
+                                    "arg1": "string1",
+                                    "arg2": null
+                                }
+                            },
+                            "run_settings": {
+                                "exe": "echo",
+                                "run_command": "srun",
+                                "run_args": {
+                                    "arg1": "string1",
+                                    "arg2": null
+                                }
+                            },
+                            "params": {
+                                "string": "Any"
+                            },
+                            "files": {
+                                "Symlink": [
+                                    "file1",
+                                    "file2"
+                                ],
+                                "Configure": [
+                                    "file3"
+                                ],
+                                "Copy": [
+                                    "file4",
+                                    "file5"
+                                ]
+                            },
+                            "colocated_db": {
+                                "settings": {
+                                    "protocol": "TCP/IP",
+                                    "port": 1111,
+                                    "interface": "lo",
+                                    "db_cpus": 1,
+                                    "limit_app_cpus": "True",
+                                    "debug": "False"
+                                },
+                                "scripts": [
+                                    {
+                                        "script1": {
+                                            "backend": "script1_torch",
+                                            "device": "script1_cpu"
+                                        }
+                                    },
+                                    {
+                                        "script2": {
+                                            "backend": "script2_torch",
+                                            "device": "script2_gpu"
+                                        }
+                                    }
+                                ],
+                                "models": [
+                                    {
+                                        "model1": {
+                                            "backend": "model1_tf",
+                                            "device": "model1_cpu"
+                                        }
+                                    },
+                                    {
+                                        "model2": {
+                                            "backend": "model2_tf",
+                                            "device": "model2_cpu"
+                                        }
+                                    }
+                                ]
+                            },
+                            "telemetry_metadata": {
+                                "status_dir": "tests/utils/status_files/model_0",
+                                "job_id": "111",
+                                "step_id": "111"
+                            },
+                            "out_file": "tests/utils/log_files/model_0.out",
+                            "err_file": "tests/utils/log_files/model_0.err"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "run_id": "2",
+            "model": [
+                {
+                    "name": "app3",
+                    "path": "app/3/path",
+                    "exe_args": [
+                        "string"
+                    ],
+                    "batch_settings": {
+                        "batch_cmd": "command",
+                        "batch_args": {
+                            "arg1": "string1",
+                            "arg2": null
+                        }
+                    },
+                    "run_settings": {
+                        "exe": "echo",
+                        "run_command": "srun",
+                        "run_args": {
+                            "arg1": "string1",
+                            "arg2": null
+                        }
+                    },
+                    "params": {
+                        "string": "Any"
+                    },
+                    "files": {
+                        "Symlink": [
+                            "file1",
+                            "file2"
+                        ],
+                        "Configure": [
+                            "file3"
+                        ],
+                        "Copy": [
+                            "file4",
+                            "file5"
+                        ]
+                    },
+                    "colocated_db": {
+                        "settings": {
+                            "protocol": "TCP/IP",
+                            "port": 1111,
+                            "interface": "lo",
+                            "db_cpus": 1,
+                            "limit_app_cpus": "True",
+                            "debug": "False"
+                        },
+                        "scripts": [],
+                        "models": [
+                            {
+                                "model1": {
+                                    "backend": "model1_tf",
+                                    "device": "model1_cpu"
+                                }
+                            },
+                            {
+                                "model2": {
+                                    "backend": "model2_tf",
+                                    "device": "model2_cpu"
+                                }
+                            }
+                        ]
+                    },
+                    "telemetry_metadata": {
+                        "status_dir": "tests/utils/status_files/model_3",
+                        "job_id": "111",
+                        "step_id": "111"
+                    },
+                    "out_file": "tests/utils/log_files/model_0.out",
+                    "err_file": "tests/utils/log_files/model_0.err"
+                },
+                {
+                    "name": "app4",
+                    "path": "app/4/path",
+                    "exe_args": [
+                        "string"
+                    ],
+                    "batch_settings": {
+                        "batch_cmd": "command",
+                        "batch_args": {
+                            "arg1": "string1",
+                            "arg2": null
+                        }
+                    },
+                    "run_settings": {
+                        "exe": "echo",
+                        "run_command": "srun",
+                        "run_args": {
+                            "arg1": "string1",
+                            "arg2": null
+                        }
+                    },
+                    "params": {
+                        "string": "Any"
+                    },
+                    "files": {
+                        "Symlink": [
+                            "file1",
+                            "file2"
+                        ],
+                        "Configure": [
+                            "file3"
+                        ],
+                        "Copy": [
+                            "file4",
+                            "file5"
+                        ]
+                    },
+                    "colocated_db": {
+                        "settings": {
+                            "protocol": "TCP/IP",
+                            "port": 1111,
+                            "interface": "lo",
+                            "db_cpus": 1,
+                            "limit_app_cpus": "True",
+                            "debug": "False"
+                        },
+                        "scripts": [
+                            {
+                                "script1": {
+                                    "backend": "script1_torch",
+                                    "device": "script1_cpu"
+                                }
+                            },
+                            {
+                                "script2": {
+                                    "backend": "script2_torch",
+                                    "device": "script2_gpu"
+                                }
+                            }
+                        ],
+                        "models": [
+                            {
+                                "model1": {
+                                    "backend": "model1_tf",
+                                    "device": "model1_cpu"
+                                }
+                            },
+                            {
+                                "model2": {
+                                    "backend": "model2_tf",
+                                    "device": "model2_cpu"
+                                }
+                            }
+                        ]
+                    },
+                    "telemetry_metadata": {
+                        "status_dir": "tests/utils/status_files/model_1",
+                        "job_id": "111",
+                        "step_id": "111"
+                    },
+                    "out_file": "tests/utils/log_files/model_1.out",
+                    "err_file": "tests/utils/log_files/model_0.err"
+                }
+            ],
+            "orchestrator": [
+                {
+                    "name": "orchestrator_2",
+                    "type": "redis",
+                    "interface": [
+                        "lo"
+                    ],
+                    "shards": [
+                        {
+                            "name": "orc 2 shard 1",
+                            "hostname": "shard1_host",
+                            "port": 22222,
+                            "out_file": "tests/utils/log_files/model_0.out",
+                            "err_file": "tests/utils/log_files/model_0.err",
+                            "conf_file": "/path/to/conf_file",
+                            "telemetry_metadata": {
+                                "status_dir": "tests/utils/status_files/model_0",
+                                "job_id": "111",
+                                "step_id": "111"
+                            }
+                        },
+                        {
+                            "name": "orc 2 shard 2",
+                            "hostname": "shard2_host",
+                            "port": 22222,
+                            "out_file": "tests/utils/log_files/model_1.out",
+                            "err_file": "tests/utils/log_files/model_1.err",
+                            "conf_file": "/path/to/conf_file",
+                            "telemetry_metadata": {
+                                "status_dir": "tests/utils/status_files/model_1",
+                                "job_id": "111",
+                                "step_id": "111"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "orchestrator_3",
+                    "type": "redis",
+                    "interface": "lo",
+                    "shards": [
+                        {
+                            "name": "orc 3 shard 1",
+                            "hostname": "shard1_host",
+                            "port": "12345",
+                            "out_file": "tests/utils/log_files/orchestrator_0.out",
+                            "err_file": "tests/utils/log_files/orchestrator_0.err",
+                            "conf_file": "/path/to/conf_file",
+                            "telemetry_metadata": {
+                                "status_dir": "tests/utils/status_files/model_3",
+                                "job_id": "111",
+                                "step_id": "111"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "ensemble": [
+                {
+                    "name": "ensemble_2",
+                    "perm_strat": "all-perm",
+                    "batch_settings": {
+                        "string": "Any1"
+                    },
+                    "params": {
+                        "string": [
+                            "Any1",
+                            "Any2",
+                            "Any3"
+                        ]
+                    },
+                    "models": [
+                        {
+                            "name": "ensemble_2_member_1",
+                            "path": "string",
+                            "exe_args": [
+                                "string"
+                            ],
+                            "batch_settings": {
+                                "batch_cmd": "command",
+                                "batch_args": {
+                                    "arg1": "string1",
+                                    "arg2": null
+                                }
+                            },
+                            "run_settings": {
+                                "exe": "echo",
+                                "run_command": "srun",
+                                "run_args": {
+                                    "arg1": "string1",
+                                    "arg2": null
+                                }
+                            },
+                            "params": {
+                                "string": "Any"
+                            },
+                            "files": {
+                                "Symlink": [
+                                    "file1",
+                                    "file2"
+                                ],
+                                "Configure": [
+                                    "file3"
+                                ],
+                                "Copy": [
+                                    "file4",
+                                    "file5"
+                                ]
+                            },
+                            "colocated_db": {
+                                "settings": {
+                                    "protocol": "TCP/IP",
+                                    "port": 1111,
+                                    "interface": "lo",
+                                    "db_cpus": 1,
+                                    "limit_app_cpus": "True",
+                                    "debug": "False"
+                                },
+                                "scripts": [],
+                                "models": []
+                            },
+                            "telemetry_metadata": {
+                                "status_dir": "tests/utils/status_files/model_0",
+                                "job_id": "111",
+                                "step_id": "111"
+                            },
+                            "out_file": "tests/utils/log_files/model_0.out",
+                            "err_file": "tests/utils/log_files/model_0.err"
+                        }
+                    ]
+                },
+                {
+                    "name": "ensemble_3",
+                    "perm_strat": "string2",
+                    "batch_settings": {
+                        "string": "Any1"
+                    },
+                    "params": {
+                        "string": [
+                            "Any1",
+                            "Any2",
+                            "Any3"
+                        ]
+                    },
+                    "models": [
+                        {
+                            "name": "ensemble_3_member_1",
+                            "path": "member 1 path",
+                            "exe_args": [
+                                "string"
+                            ],
+                            "batch_settings": {
+                                "batch_cmd": "command",
+                                "batch_args": {
+                                    "arg1": "string1",
+                                    "arg2": null
+                                }
+                            },
+                            "run_settings": {
+                                "exe": "echo",
+                                "run_command": "srun",
+                                "run_args": {
+                                    "arg1": "string1",
+                                    "arg2": null
+                                }
+                            },
+                            "params": {
+                                "string": "Any"
+                            },
+                            "files": {
+                                "Symlink": [
+                                    "file1",
+                                    "file2"
+                                ],
+                                "Configure": [
+                                    "file3"
+                                ],
+                                "Copy": [
+                                    "file4",
+                                    "file5"
+                                ]
+                            },
+                            "colocated_db": {
+                                "settings": {
+                                    "protocol": "TCP/IP",
+                                    "port": 1111,
+                                    "interface": "lo",
+                                    "db_cpus": 1,
+                                    "limit_app_cpus": "True",
+                                    "debug": "False"
+                                },
+                                "scripts": [
+                                    {
+                                        "script1": {
+                                            "backend": "script1_torch",
+                                            "device": "script1_cpu"
+                                        }
+                                    },
+                                    {
+                                        "script2": {
+                                            "backend": "script2_torch",
+                                            "device": "script2_gpu"
+                                        }
+                                    }
+                                ],
+                                "models": [
+                                    {
+                                        "model1": {
+                                            "backend": "model1_tf",
+                                            "device": "model1_cpu"
+                                        }
+                                    },
+                                    {
+                                        "model2": {
+                                            "backend": "model2_tf",
+                                            "device": "model2_cpu"
+                                        }
+                                    }
+                                ]
+                            },
+                            "telemetry_metadata": {
+                                "status_dir": "tests/utils/status_files/model_3",
+                                "job_id": "111",
+                                "step_id": "111"
+                            },
+                            "out_file": "tests/utils/log_files/model_0.out",
+                            "err_file": "tests/utils/log_files/model_0.err"
+                        },
+                        {
+                            "name": "ensemble_3_member_2",
+                            "path": "member 2 path",
+                            "exe_args": [
+                                "string"
+                            ],
+                            "batch_settings": {
+                                "batch_cmd": "command",
+                                "batch_args": {
+                                    "arg1": "string1"
+                                }
+                            },
+                            "run_settings": {
+                                "exe": "echo",
+                                "run_command": "srun",
+                                "run_args": {
+                                    "arg1": "string1",
+                                    "arg2": null
+                                }
+                            },
+                            "params": {
+                                "string": "Any"
+                            },
+                            "files": {
+                                "Symlink": [
+                                    "file1",
+                                    "file2"
+                                ],
+                                "Configure": [
+                                    "file3"
+                                ],
+                                "Copy": [
+                                    "file4",
+                                    "file5"
+                                ]
+                            },
+                            "colocated_db": {
+                                "settings": {
+                                    "protocol": "TCP/IP",
+                                    "port": 1111,
+                                    "interface": "lo",
+                                    "db_cpus": 1,
+                                    "limit_app_cpus": "True",
+                                    "debug": "False"
+                                },
+                                "scripts": [
+                                    {
+                                        "script1": {
+                                            "backend": "script1_torch",
+                                            "device": "script1_cpu"
+                                        }
+                                    },
+                                    {
+                                        "script2": {
+                                            "backend": "script2_torch",
+                                            "device": "script2_gpu"
+                                        }
+                                    }
+                                ],
+                                "models": [
+                                    {
+                                        "model1": {
+                                            "backend": "model1_tf",
+                                            "device": "model1_cpu"
+                                        }
+                                    },
+                                    {
+                                        "model2": {
+                                            "backend": "model2_tf",
+                                            "device": "model2_cpu"
+                                        }
+                                    }
+                                ]
+                            },
+                            "telemetry_metadata": {
+                                "status_dir": "tests/utils/status_files/model_1",
+                                "job_id": "111",
+                                "step_id": "111"
+                            },
+                            "out_file": "tests/utils/log_files/model_1.out",
+                            "err_file": "tests/utils/log_files/model_1.err"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/utils/manifest_files/JSONDecodererror.json
+++ b/tests/utils/manifest_files/JSONDecodererror.json
@@ -1,7 +1,7 @@
 
     "schema info" : {
         "schema_name" : "entity manifest",
-        "version" : "0.0.2"
+        "version" : "0.0.3"
     },
     "experiment" : {},
     "runs": []

--- a/tests/utils/manifest_files/fauxexp/.smartsim/telemetry/manifest.json
+++ b/tests/utils/manifest_files/fauxexp/.smartsim/telemetry/manifest.json
@@ -1,7 +1,7 @@
 {
     "schema info": {
         "schema_name": "entity manifest",
-        "version": "0.0.2"
+        "version": "0.0.3"
     },
     "experiment": {
         "name": "my-experiment",

--- a/tests/utils/manifest_files/malformed_apps.json
+++ b/tests/utils/manifest_files/malformed_apps.json
@@ -1,7 +1,7 @@
 {
     "schema info": {
         "schema_name": "entity manifest",
-        "version": "0.0.2"
+        "version": "0.0.3"
     },
     "experiment": {
         "name": "my-experiment",

--- a/tests/utils/manifest_files/malformed_ensembles.json
+++ b/tests/utils/manifest_files/malformed_ensembles.json
@@ -1,7 +1,7 @@
 {
     "schema info": {
         "schema_name": "entity manifest",
-        "version": "0.0.2"
+        "version": "0.0.3"
     },
     "experiment": {
         "name": "my-experiment",

--- a/tests/utils/manifest_files/malformed_orcs.json
+++ b/tests/utils/manifest_files/malformed_orcs.json
@@ -1,7 +1,7 @@
 {
     "schema info": {
         "schema_name": "entity manifest",
-        "version": "0.0.2"
+        "version": "0.0.3"
     },
     "experiment": {
         "name": "my-experiment",

--- a/tests/utils/manifest_files/manifesttest.json
+++ b/tests/utils/manifest_files/manifesttest.json
@@ -1,7 +1,7 @@
 {
     "schema info": {
         "schema_name": "entity manifest",
-        "version": "0.0.2"
+        "version": "0.0.3"
     },
     "experiment": {
         "name": "my-experiment",

--- a/tests/utils/manifest_files/no_apps_manifest.json
+++ b/tests/utils/manifest_files/no_apps_manifest.json
@@ -1,7 +1,7 @@
 {
     "schema info": {
         "schema_name": "entity manifest",
-        "version": "0.0.2"
+        "version": "0.0.3"
     },
     "experiment": {
         "name": "my-experiment",

--- a/tests/utils/manifest_files/no_ensembles_manifest.json
+++ b/tests/utils/manifest_files/no_ensembles_manifest.json
@@ -1,7 +1,7 @@
 {
     "schema info": {
         "schema_name": "entity manifest",
-        "version": "0.0.2"
+        "version": "0.0.3"
     },
     "experiment": {
         "name": "my-experiment",

--- a/tests/utils/manifest_files/no_experiment_manifest.json
+++ b/tests/utils/manifest_files/no_experiment_manifest.json
@@ -1,7 +1,7 @@
 {
     "schema info" : {
         "schema_name" : "entity manifest",
-        "version" : "0.0.2"
+        "version" : "0.0.3"
     },
     "experiment" : {},
     "runs": []

--- a/tests/utils/manifest_files/no_orchestrator_manifest.json
+++ b/tests/utils/manifest_files/no_orchestrator_manifest.json
@@ -1,7 +1,7 @@
 {
     "schema info": {
         "schema_name": "entity manifest",
-        "version": "0.0.2"
+        "version": "0.0.3"
     },
     "experiment": {
         "name": "my-experiment",

--- a/tests/utils/manifest_files/no_running.json
+++ b/tests/utils/manifest_files/no_running.json
@@ -1,7 +1,7 @@
 {
     "schema info": {
         "schema_name": "entity manifest",
-        "version": "0.0.2"
+        "version": "0.0.3"
     },
     "experiment": {
         "name": "my-experiment",


### PR DESCRIPTION
In the PR I updated the version of SmartDashboard and also updated the version of the new manifests to 0.0.3. To make the dashboard backwards compatible, I instantiate "err_file" and "out_file" in the schema `HasOutErrFiles` to be an empty string. If a 0.0.2 manifest is used with the 0.0.3 dashboard, the experiment logs will be empty.