### PR TITLE
Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 SmartDashboard is an add-on to SmartSim that provides a dashboard to help users understand and monitor their SmartSim experiments in a visual way. Configuration, status, and logs are available for all launched entities within an experiment for easy inspection.
 
-A ``Telemetry Monitor`` is a new background process that is launched along with the experiment
-that helps SmartDashboard properly display data. The ``Telemetry Monitor`` can be disabled by
+A ``Telemetry Monitor`` is a background process that is launched along with the experiment
+that produces the data displayed by SmartDashboard. The ``Telemetry Monitor`` can be disabled by
 adding ``export SMARTSIM_TELEMETRY_ENABLE=0`` as an environment variable. When disabled, SmartDashboard
 will not display any data. To re-enable, set the ``SMARTSIM_TELEMETRY_ENABLE`` environment variable to ``1``
 with ``export SMARTSIM_TELEMETRY_ENABLE=1``.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 SmartDashboard is an add-on to SmartSim that provides a dashboard to help users understand and monitor their SmartSim experiments in a visual way. Configuration, status, and logs are available for all launched entities within an experiment for easy inspection.
 
+A ``Telemetry Monitor`` is a new background process that is launched along with the experiment
+that helps SmartDashboard properly display data. The ``Telemetry Monitor`` can be disabled by
+adding !!!!!!!FINDOUTFINALAPI!!!!!!!!! to the driver script. Experiment metadata is also stored in
+the ``.smartsim`` directory, a hidden folder for internal api use and used by the dashboard.
+Deletion of the experiment folder will remove all experiment metadata.
+
 ## Installation
 
 It's important to note that SmartDashboard only works while using SmartSim, so SmartSim will need to be installed as well.
@@ -9,7 +15,7 @@ SmartSim installation docs can be found [here](https://www.craylabs.org/docs/ins
 
 ### User Install
 
-Run `pip install git+https://github.com/CrayLabs/SmartDashboard.git` to install SmartDashboard without cloning the repository.
+Run `pip install smartdashboard` to install SmartDashboard without cloning the repository.
 
 ### Developer Install
 
@@ -88,6 +94,6 @@ The dashboard is also persistent, meaning that a user can still launch and use t
 
 Once the dashboard is launched, a browser will open to `http://localhost:<port>`. SmartDashboard currently has two tabs on the left hand side.
   
-`Experiment Overview:` This tab is where configuration information, statuses, and logs are located for each launched entity of the experiment. The `Experiment` section displays configuaration information for the overall experiment. In the `Applications` section, also known as SmartSim `Models`, select a launched application to see its status, what it was configured with, and its logs. The `Orchestrators` section also provides configuration and status information, as well as logs per shard for a selected orchestrator. Finally, in the `Ensembles` section, select an ensemble to see its status and configuration. Then select any of its members to see its status, configuration, and logs.
+`Experiment Overview:` This tab is where configuration information, statuses, and logs are located for each launched entity of the experiment. The `Experiment` section displays configuration information for the overall experiment and its logs. In the `Applications` section, also known as SmartSim `Models`, select a launched application to see its status, what it was configured with, and its logs. The `Orchestrators` section also provides configuration and status information, as well as logs per shard for a selected orchestrator. Finally, in the `Ensembles` section, select an ensemble to see its status and configuration. Then select any of its members to see its status, configuration, and logs.
   
 `Help:` This tab links to SmartSim documentation and provides a SmartSim contact for support.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@ SmartDashboard is an add-on to SmartSim that provides a dashboard to help users 
 
 A ``Telemetry Monitor`` is a new background process that is launched along with the experiment
 that helps SmartDashboard properly display data. The ``Telemetry Monitor`` can be disabled by
-adding !!!!!!!FINDOUTFINALAPI!!!!!!!!! to the driver script. Experiment metadata is also stored in
-the ``.smartsim`` directory, a hidden folder for internal api use and used by the dashboard.
+adding ``export SMARTSIM_TELEMETRY_ENABLE=0`` as an environment variable. When disabled, SmartDashboard
+will not display any data. To re-enable, set the ``SMARTSIM_TELEMETRY_ENABLE`` environment variable to ``1``
+with ``export SMARTSIM_TELEMETRY_ENABLE=1``.
+
+Experiment metadata is also stored in the ``.smartsim`` directory, a hidden folder for internal api use and used by the dashboard.
 Deletion of the experiment folder will remove all experiment metadata.
 
 ## Installation

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,8 +8,11 @@ Release TBD
 
 Description
 
-- Added defined schemas for entity objects.
-- Added experiment level logs to the dashboard.
+- Added defined schemas for entity objects. (SmartDashboard-PR31_)
+- Added experiment level logs to the dashboard. (SmartDashboard-PR37_)
+
+.. _SmartDashboard-PR31: https://github.com/CrayLabs/SmartDashboard/pull/31
+.. _SmartDashboard-PR37: https://github.com/CrayLabs/SmartDashboard/pull/37
 
 
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+0.0.3
+-----
+
+Release TBD
+
+Description
+
+- Added defined schemas for entity objects.
+- Added experiment level logs to the dashboard.
+
+
+
 0.0.2
 -----
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 0.0.3
 -----
 
-Release TBD
+Released on 15 February 2024
 
 Description
 

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -8,9 +8,12 @@ and monitor their SmartSim experiments in a visual way. Configuration, status, a
 are available for all launched entities within an experiment for easy inspection.
 
 A ``Telemetry Monitor`` is a new background process that is launched along with the experiment
-that helps ``SmartDashboard`` properly display data. The ``Telemetry Monitor`` can be disabled by
-adding !!!!!!!FINDOUTFINALAPI!!!!!!!!! to the driver script. Experiment metadata is also stored in
-the ``.smartsim`` directory, a hidden folder for internal api use and used by the dashboard.
+that helps SmartDashboard properly display data. The ``Telemetry Monitor`` can be disabled by
+adding ``export SMARTSIM_TELEMETRY_ENABLE=0`` as an environment variable. When disabled, SmartDashboard
+will not display any data. To re-enable, set the ``SMARTSIM_TELEMETRY_ENABLE`` environment variable to ``1``
+with ``export SMARTSIM_TELEMETRY_ENABLE=1``.
+
+Experiment metadata is also stored in the ``.smartsim`` directory, a hidden folder for internal api use and used by the dashboard.
 Deletion of the experiment folder will remove all experiment metadata.
 
 

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -7,8 +7,8 @@ SmartDashboard
 and monitor their SmartSim experiments in a visual way. Configuration, status, and logs
 are available for all launched entities within an experiment for easy inspection.
 
-A ``Telemetry Monitor`` is a new background process that is launched along with the experiment
-that helps SmartDashboard properly display data. The ``Telemetry Monitor`` can be disabled by
+A ``Telemetry Monitor`` is a background process that is launched along with the experiment
+that produces the data displayed by SmartDashboard. The ``Telemetry Monitor`` can be disabled by
 adding ``export SMARTSIM_TELEMETRY_ENABLE=0`` as an environment variable. When disabled, SmartDashboard
 will not display any data. To re-enable, set the ``SMARTSIM_TELEMETRY_ENABLE`` environment variable to ``1``
 with ``export SMARTSIM_TELEMETRY_ENABLE=1``.

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -8,7 +8,8 @@ and monitor their SmartSim experiments in a visual way. Configuration, status, a
 are available for all launched entities within an experiment for easy inspection.
 
 A ``Telemetry Monitor`` is a new background process that is launched along with the experiment
-that helps ``SmartDashboard`` properly display data. Experiment metadata is also stored in
+that helps ``SmartDashboard`` properly display data. The ``Telemetry Monitor`` can be disabled by
+adding !!!!!!!FINDOUTFINALAPI!!!!!!!!! to the driver script. Experiment metadata is also stored in
 the ``.smartsim`` directory, a hidden folder for internal api use and used by the dashboard.
 Deletion of the experiment folder will remove all experiment metadata.
 
@@ -24,7 +25,7 @@ found `here <https://www.craylabs.org/docs/installation_instructions/basic.html>
 
 User Install:
 
-Run ``pip install git+https://github.com/CrayLabs/SmartDashboard.git`` to install
+Run ``pip install smartdashboard`` to install
 SmartDashboard without cloning the repository.
 
 Developer Install:
@@ -124,7 +125,7 @@ Once displayed in the browser, SmartDashboard currently has two tabs on the left
   
 ``Experiment Overview:`` This tab is where configuration information, statuses, and 
 logs are located for each launched entity of the experiment. The ``Experiment`` 
-section displays configuaration information for the overall experiment. In the ``Applications`` 
+section displays configuration information for the overall experiment and its logs. In the ``Applications`` 
 section, also known as SmartSim ``Models``, select a launched application to see its status, 
 what it was configured with, and its logs. The ``Orchestrators`` section also provides 
 configuration and status information, as well as logs per shard for a selected orchestrator. 


### PR DESCRIPTION
In this PR I updated the docs for the`README`, `overview.rst`, and `changelog`. The bulk of the additions added are to make it clear to a user that the `Telemetry Monitor` can be disabled, but it will make the dashboard fail. I also describe how to re-enable it if they've disabled it.

I _think_ this is how we will be enabling and disabling telemetry for this release, but that could change.