### PR TITLE
Manifest file tracking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ readme = "README.md"
 dependencies = [
     "pandas>=2.0.0",
     "pydantic>=2.5.2",
-    "streamlit>=1.28.0",
+    "streamlit>=1.28.0, <1.31.0",
     "watchdog>=3.0.0",
 ]
 

--- a/smartdashboard/Experiment_Overview.py
+++ b/smartdashboard/Experiment_Overview.py
@@ -35,7 +35,7 @@ from subprocess import run
 import streamlit as st
 
 from smartdashboard.utils.errors import SSDashboardError
-from smartdashboard.utils.ManifestReader import load_manifest
+from smartdashboard.utils.ManifestReader import create_filereader
 from smartdashboard.utils.pageSetup import local_css, set_streamlit_page_config
 from smartdashboard.view_builders import error_builder, overview_builder
 from smartdashboard.views import EntityView
@@ -53,7 +53,8 @@ def build_app(manifest_path: str) -> None:
     local_css(str(curr_path / "static/style.css"))
 
     try:
-        manifest, manifest_reader = load_manifest(manifest_path)
+        manifest_reader = create_filereader(manifest_path)
+        manifest = manifest_reader.get_manifest()
     except SSDashboardError as ex:
         error_builder(ex)
     else:

--- a/smartdashboard/Experiment_Overview.py
+++ b/smartdashboard/Experiment_Overview.py
@@ -31,6 +31,7 @@ import sys
 import time
 import typing as t
 from subprocess import run
+
 import streamlit as st
 
 from smartdashboard.utils.errors import SSDashboardError

--- a/smartdashboard/Experiment_Overview.py
+++ b/smartdashboard/Experiment_Overview.py
@@ -31,6 +31,7 @@ import sys
 import time
 import typing as t
 from subprocess import run
+import streamlit as st
 
 from smartdashboard.utils.errors import SSDashboardError
 from smartdashboard.utils.ManifestReader import load_manifest
@@ -51,7 +52,7 @@ def build_app(manifest_path: str) -> None:
     local_css(str(curr_path / "static/style.css"))
 
     try:
-        manifest = load_manifest(manifest_path)
+        manifest, manifest_reader = load_manifest(manifest_path)
     except SSDashboardError as ex:
         error_builder(ex)
     else:
@@ -64,9 +65,10 @@ def build_app(manifest_path: str) -> None:
         )
 
         while True:
+            if manifest_reader.has_changed:
+                st.rerun()
             for v in to_update:
                 v.update()
-
             time.sleep(1)
 
 

--- a/smartdashboard/utils/ManifestReader.py
+++ b/smartdashboard/utils/ManifestReader.py
@@ -27,8 +27,8 @@
 import io
 import itertools
 import json
-import typing as t
 import os
+import typing as t
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Dict, List
@@ -111,7 +111,7 @@ class ManifestFileReader(ManifestReader):
                 file=file_path,
                 exception=version_exception,
             )
-        
+
     @property
     def has_changed(self) -> bool:
         return self._last_modified != os.path.getmtime(self._file_path)

--- a/smartdashboard/utils/ManifestReader.py
+++ b/smartdashboard/utils/ManifestReader.py
@@ -114,6 +114,11 @@ class ManifestFileReader(ManifestReader):
 
     @property
     def has_changed(self) -> bool:
+        """Check if the manifest file has been modified
+
+        :return: If the file has been modified
+        :rtype: bool
+        """
         return self._last_modified != os.path.getmtime(self._file_path)
 
     def get_manifest(self) -> Manifest:

--- a/tests/test_ManifestReader/test_manifestfilereader_get_manifest.py
+++ b/tests/test_ManifestReader/test_manifestfilereader_get_manifest.py
@@ -38,22 +38,6 @@ from smartdashboard.utils.ManifestReader import Manifest, create_filereader
             "tests/utils/manifest_files/manifesttest.json", 2, 4, 3, 3, Manifest
         ),
         pytest.param(
-            "tests/utils/manifest_files/no_experiment_manifest.json",
-            0,
-            0,
-            0,
-            0,
-            MalformedManifestError,
-        ),
-        pytest.param(
-            "tests/utils/manifest_files/malformed_apps.json",
-            0,
-            0,
-            0,
-            0,
-            MalformedManifestError,
-        ),
-        pytest.param(
             "tests/utils/manifest_files/no_apps_manifest.json",
             2,
             0,
@@ -90,16 +74,29 @@ from smartdashboard.utils.ManifestReader import Manifest, create_filereader
 def test_get_manifest(
     json_file, runs_length, app_length, orc_length, ens_length, return_type
 ):
-    if return_type == MalformedManifestError:
-        with pytest.raises(return_type):
-            manifest_file_reader = create_filereader(json_file)
-            manifest_file_reader.get_manifest()
-    
-    else:
-        manifest_file_reader = create_filereader(json_file)
-        manifest = manifest_file_reader.get_manifest()
-        assert len(list(manifest.runs)) == runs_length
-        assert len(list(manifest.apps_with_run_ctx)) == app_length
-        assert len(list(manifest.orcs_with_run_ctx)) == orc_length
-        assert len(list(manifest.ensemble_with_run_ctx)) == ens_length
-        assert type(manifest) == return_type
+    manifest_file_reader = create_filereader(json_file)
+    manifest = manifest_file_reader.get_manifest()
+    assert len(list(manifest.runs)) == runs_length
+    assert len(list(manifest.apps_with_run_ctx)) == app_length
+    assert len(list(manifest.orcs_with_run_ctx)) == orc_length
+    assert len(list(manifest.ensemble_with_run_ctx)) == ens_length
+    assert type(manifest) == return_type
+
+
+@pytest.mark.parametrize(
+    "json_file, return_type",
+    [
+        pytest.param(
+            "tests/utils/manifest_files/no_experiment_manifest.json",
+            MalformedManifestError,
+        ),
+        pytest.param(
+            "tests/utils/manifest_files/malformed_apps.json",
+            MalformedManifestError,
+        ),
+    ],
+)
+def test_get_manifest_malformed(json_file, return_type):
+    manifest_file_reader = create_filereader(json_file)
+    with pytest.raises(return_type):
+        manifest_file_reader.get_manifest()

--- a/tests/test_ManifestReader/test_manifestfilereader_get_manifest.py
+++ b/tests/test_ManifestReader/test_manifestfilereader_get_manifest.py
@@ -28,7 +28,7 @@ import pytest
 from pydantic import ValidationError
 
 from smartdashboard.utils.errors import MalformedManifestError
-from smartdashboard.utils.ManifestReader import Manifest, ManifestFileReader
+from smartdashboard.utils.ManifestReader import Manifest, create_filereader
 
 
 @pytest.mark.parametrize(
@@ -39,6 +39,14 @@ from smartdashboard.utils.ManifestReader import Manifest, ManifestFileReader
         ),
         pytest.param(
             "tests/utils/manifest_files/no_experiment_manifest.json",
+            0,
+            0,
+            0,
+            0,
+            MalformedManifestError,
+        ),
+        pytest.param(
+            "tests/utils/manifest_files/malformed_apps.json",
             0,
             0,
             0,
@@ -83,9 +91,9 @@ def test_get_manifest(
     json_file, runs_length, app_length, orc_length, ens_length, return_type
 ):
     try:
-        manifest_file_reader = ManifestFileReader(json_file)
+        manifest_file_reader = create_filereader(json_file)
         manifest = manifest_file_reader.get_manifest()
-    except ValidationError as v:
+    except MalformedManifestError as v:
         assert return_type == MalformedManifestError
         return
     assert len(list(manifest.runs)) == runs_length

--- a/tests/test_ManifestReader/test_manifestfilereader_get_manifest.py
+++ b/tests/test_ManifestReader/test_manifestfilereader_get_manifest.py
@@ -90,14 +90,16 @@ from smartdashboard.utils.ManifestReader import Manifest, create_filereader
 def test_get_manifest(
     json_file, runs_length, app_length, orc_length, ens_length, return_type
 ):
-    try:
+    if return_type == MalformedManifestError:
+        with pytest.raises(return_type):
+            manifest_file_reader = create_filereader(json_file)
+            manifest_file_reader.get_manifest()
+    
+    else:
         manifest_file_reader = create_filereader(json_file)
         manifest = manifest_file_reader.get_manifest()
-    except MalformedManifestError as v:
-        assert return_type == MalformedManifestError
-        return
-    assert len(list(manifest.runs)) == runs_length
-    assert len(list(manifest.apps_with_run_ctx)) == app_length
-    assert len(list(manifest.orcs_with_run_ctx)) == orc_length
-    assert len(list(manifest.ensemble_with_run_ctx)) == ens_length
-    assert type(manifest) == return_type
+        assert len(list(manifest.runs)) == runs_length
+        assert len(list(manifest.apps_with_run_ctx)) == app_length
+        assert len(list(manifest.orcs_with_run_ctx)) == orc_length
+        assert len(list(manifest.ensemble_with_run_ctx)) == ens_length
+        assert type(manifest) == return_type

--- a/tests/test_ManifestReader/test_manifestfilereader_has_changed.py
+++ b/tests/test_ManifestReader/test_manifestfilereader_has_changed.py
@@ -1,0 +1,67 @@
+# BSD 2-Clause License
+#
+# Copyright (c) 2021-2024, Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import pathlib
+
+import pytest
+
+from smartdashboard.utils.ManifestReader import create_filereader
+
+
+@pytest.mark.parametrize(
+    "json_file, touch",
+    [
+        pytest.param(
+            pathlib.Path("tests/utils/manifest_files/manifesttest.json"), True
+        ),
+        pytest.param(
+            pathlib.Path("tests/utils/manifest_files/0.0.2_manifest.json"),
+            False,
+        ),
+        pytest.param(
+            pathlib.Path("tests/utils/manifest_files/no_apps_manifest.json"),
+            True,
+        ),
+        pytest.param(
+            pathlib.Path("tests/utils/manifest_files/no_ensembles_manifest.json"),
+            True,
+        ),
+        pytest.param(
+            pathlib.Path("tests/utils/manifest_files/no_orchestrator_manifest.json"),
+            False,
+        ),
+    ],
+)
+def test_has_changed(json_file, touch):
+    manifest_reader = create_filereader(json_file)
+
+    assert manifest_reader.has_changed == False
+
+    if touch:
+        pathlib.Path.touch(json_file)
+        assert manifest_reader.has_changed == True
+    else:
+        assert manifest_reader.has_changed == False

--- a/tests/test_ManifestReader/test_manifestfilereader_has_changed.py
+++ b/tests/test_ManifestReader/test_manifestfilereader_has_changed.py
@@ -61,7 +61,7 @@ def test_has_changed(json_file, touch):
     assert manifest_reader.has_changed == False
 
     if touch:
-        pathlib.Path.touch(json_file)
+        json_file.touch()
         assert manifest_reader.has_changed == True
     else:
         assert manifest_reader.has_changed == False

--- a/tests/test_ManifestReader/test_manifestfilereader_has_changed.py
+++ b/tests/test_ManifestReader/test_manifestfilereader_has_changed.py
@@ -35,23 +35,14 @@ from smartdashboard.utils.ManifestReader import create_filereader
     "json_file, touch",
     [
         pytest.param(
-            pathlib.Path("tests/utils/manifest_files/manifesttest.json"), True
-        ),
-        pytest.param(
-            pathlib.Path("tests/utils/manifest_files/0.0.2_manifest.json"),
-            False,
-        ),
-        pytest.param(
-            pathlib.Path("tests/utils/manifest_files/no_apps_manifest.json"),
+            pathlib.Path("tests/utils/manifest_files/manifesttest.json"),
             True,
-        ),
-        pytest.param(
-            pathlib.Path("tests/utils/manifest_files/no_ensembles_manifest.json"),
-            True,
+            id="ensure change seen",
         ),
         pytest.param(
             pathlib.Path("tests/utils/manifest_files/no_orchestrator_manifest.json"),
             False,
+            id="ensure change not seen",
         ),
     ],
 )


### PR DESCRIPTION
In this PR I added an if check within the update loop that checks to see if there have been changes to the manifest file. If there have been changes, the app reruns. 

We wanted to add this because new runs can be added to the manifest as the SmartSim experiment progresses, and the new changes to the manifest file were not being displayed in the dashboard without the user refreshing the page or interacting with widgets.