### PR TITLE
Bump SmartDashboard to version 0.0.4

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -6,19 +6,21 @@ Development branch
 
 Description
 
+- Bump version to 0.0.4, exclude streamlit version 1.31.X (SmartDashboard-PR50_)
 - Drop Python 3.8 support, add 3.11 support. (SmartDashboard-PR49_)
 - Add Database Telemetry page. (SmartDashboard-PR38_)
 - Add Github Actions workflow that checks if changelog is edited
   on pull requests into develop. (SmartDashboard-PR47_)
 - Add manifest file tracking. (SmartDashboard-PR46_)
 
+.. _SmartDashboard-PR50: https://github.com/CrayLabs/SmartDashboard/pull/50
 .. _SmartDashboard-PR49: https://github.com/CrayLabs/SmartDashboard/pull/49
 .. _SmartDashboard-PR38: https://github.com/CrayLabs/SmartDashboard/pull/38
 .. _SmartDashboard-PR47: https://github.com/CrayLabs/SmartDashboard/pull/47
 .. _SmartDashboard-PR46: https://github.com/CrayLabs/SmartDashboard/pull/46
 
 
-0.0.4
+0.0.3
 -----
 
 Released on 15 February 2024

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -16,7 +16,7 @@ Description
 .. _SmartDashboard-PR46: https://github.com/CrayLabs/SmartDashboard/pull/46
 
 
-0.0.3
+0.0.4
 -----
 
 Released on 15 February 2024

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -22,7 +22,7 @@ copyright = '2021-2024, Hewlett Packard Enterprise'
 author = 'Hewlett Packard Enterprise'
 
 # The full version, including alpha/beta/rc tags
-version = "0.0.3"
+version = "0.0.4"
 
 # The full version, including alpha/beta/rc tags
 release = version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smartdashboard"
-version = "0.0.3"
+version = "4"
 requires-python = ">=3.8,<3.11"
 authors = [
   {name = "CrayLabs: a Hewlett Packard Enterprise OSS Organization", email = "craylabs@hpe.com"},
@@ -53,7 +53,7 @@ dependencies = [
     "altair>=5.2.0",
     "pandas>=2.0.0",
     "pydantic>=2.5.2",
-    "streamlit>=1.28.0, <1.31.0",
+    "streamlit>=1.28.0, !=1.31.0, !=1.31.1",
     "watchdog>=3.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smartdashboard"
-version = "4"
+version = "0.0.4"
 requires-python = ">=3.8,<3.11"
 authors = [
   {name = "CrayLabs: a Hewlett Packard Enterprise OSS Organization", email = "craylabs@hpe.com"},

--- a/smartdashboard/utils/ManifestReader.py
+++ b/smartdashboard/utils/ManifestReader.py
@@ -102,9 +102,9 @@ class ManifestFileReader(ManifestReader):
                 "Version data is malformed.", file=str(self._file_path), exception=key
             ) from key
 
-        if version not in ("0.0.2", "0.0.3"):
+        if version not in ("0.0.2", "0.0.3", "0.0.4"):
             version_exception = Exception(
-                "SmartDashboard version 0.0.3 is unable to parse manifest "
+                "SmartDashboard version 0.0.4 is unable to parse manifest "
                 f"file at version {version}."
             )
             raise VersionIncompatibilityError(

--- a/tests/test_ManifestReader/test_manifestfilereader_create_filereader.py
+++ b/tests/test_ManifestReader/test_manifestfilereader_create_filereader.py
@@ -41,6 +41,10 @@ from smartdashboard.utils.ManifestReader import ManifestFileReader, create_filer
             ManifestFileReader,
         ),
         pytest.param(
+            "tests/utils/manifest_files/0.0.3_manifest.json",
+            ManifestFileReader,
+        ),
+        pytest.param(
             "tests/utils/manifest_files/no_apps_manifest.json",
             ManifestFileReader,
         ),

--- a/tests/test_ManifestReader/test_manifestfilereader_get_manifest.py
+++ b/tests/test_ManifestReader/test_manifestfilereader_get_manifest.py
@@ -69,6 +69,14 @@ from smartdashboard.utils.ManifestReader import Manifest, create_filereader
             3,
             Manifest,
         ),
+        pytest.param(
+            "tests/utils/manifest_files/0.0.3_manifest.json",
+            1,
+            2,
+            1,
+            1,
+            Manifest,
+        ),
     ],
 )
 def test_get_manifest(

--- a/tests/utils/manifest_files/0.0.3_manifest.json
+++ b/tests/utils/manifest_files/0.0.3_manifest.json
@@ -1,0 +1,329 @@
+{
+    "schema info": {
+        "schema_name": "entity manifest",
+        "version": "0.0.3"
+    },
+    "experiment": {
+        "name": "my-experiment",
+        "path": "experiment/path",
+        "launcher": "local",
+        "out_file": "tests/utils/log_files/model_0.out",
+        "err_file": "tests/utils/log_files/model_0.err"
+    },
+    "runs": [
+        {
+            "run_id": "1",
+            "model": [
+                {
+                    "name": "app1",
+                    "path": "app/1/path",
+                    "exe_args": [
+                        "string"
+                    ],
+                    "batch_settings": {
+                        "batch_cmd": "command",
+                        "batch_args": {
+                            "arg1": "string1",
+                            "arg2": null
+                        }
+                    },
+                    "run_settings": {
+                        "exe": "echo",
+                        "run_command": "srun",
+                        "run_args": {
+                            "arg1": "string1",
+                            "arg2": null
+                        }
+                    },
+                    "params": {
+                        "param": "param value"
+                    },
+                    "files": {
+                        "Symlink": [
+                            "file1",
+                            "file2"
+                        ],
+                        "Configure": [
+                            "file3"
+                        ],
+                        "Copy": [
+                            "file4",
+                            "file5"
+                        ]
+                    },
+                    "colocated_db": {
+                        "settings": {
+                            "protocol": "TCP/IP",
+                            "port": 1111,
+                            "interface": "lo",
+                            "db_cpus": 1,
+                            "limit_app_cpus": "True",
+                            "debug": "False"
+                        },
+                        "scripts": [
+                            {
+                                "script1": {
+                                    "backend": "script1_torch",
+                                    "device": "script1_cpu"
+                                }
+                            },
+                            {
+                                "script2": {
+                                    "backend": "script2_torch",
+                                    "device": "script2_gpu"
+                                }
+                            }
+                        ],
+                        "models": [
+                            {
+                                "model1": {
+                                    "backend": "model1_tf",
+                                    "device": "model1_cpu"
+                                }
+                            },
+                            {
+                                "model2": {
+                                    "backend": "model2_tf",
+                                    "device": "model2_cpu"
+                                }
+                            }
+                        ]
+                    },
+                    "telemetry_metadata": {
+                        "status_dir": "tests/utils/status_files/model_0",
+                        "job_id": "111",
+                        "step_id": "111"
+                    },
+                    "out_file": "tests/utils/log_files/model_0.out",
+                    "err_file": "tests/utils/log_files/model_0.err"
+                },
+                {
+                    "name": "app2",
+                    "path": "app/2/path",
+                    "exe_args": [
+                        "string1",
+                        "string2",
+                        "string3"
+                    ],
+                    "batch_settings": {
+                        "batch_cmd": "command",
+                        "batch_args": {
+                            "arg1": "string1",
+                            "arg2": null
+                        }
+                    },
+                    "run_settings": {
+                        "exe": "echo",
+                        "run_command": "srun",
+                        "run_args": {
+                            "arg1": "string1",
+                            "arg2": null
+                        }
+                    },
+                    "params": {
+                        "string": [
+                            "Any"
+                        ]
+                    },
+                    "files": {
+                        "Symlink": [
+                            "file1",
+                            "file2"
+                        ],
+                        "Configure": [
+                            "file3"
+                        ],
+                        "Copy": [
+                            "file4",
+                            "file5"
+                        ]
+                    },
+                    "colocated_db": {
+                        "settings": {
+                            "protocol": "TCP/IP",
+                            "port": 1111,
+                            "interface": "lo",
+                            "db_cpus": 1,
+                            "limit_app_cpus": "True",
+                            "debug": "False"
+                        },
+                        "scripts": [
+                            {
+                                "script1": {
+                                    "backend": "script1_torch",
+                                    "device": "script1_cpu"
+                                }
+                            },
+                            {
+                                "script2": {
+                                    "backend": "script2_torch",
+                                    "device": "script2_gpu"
+                                }
+                            }
+                        ],
+                        "models": [
+                            {
+                                "model1": {
+                                    "backend": "model1_tf",
+                                    "device": "model1_cpu"
+                                }
+                            },
+                            {
+                                "model2": {
+                                    "backend": "model2_tf",
+                                    "device": "model2_cpu"
+                                }
+                            }
+                        ]
+                    },
+                    "telemetry_metadata": {
+                        "status_dir": "tests/utils/status_files/model_1",
+                        "job_id": "111",
+                        "step_id": "111"
+                    },
+                    "out_file": "tests/utils/log_files/model_1.out",
+                    "err_file": "tests/utils/log_files/model_1.err"
+                }
+            ],
+            "orchestrator": [
+                {
+                    "name": "orchestrator_1",
+                    "type": "redis",
+                    "interface": [
+                        "lo",
+                        "lo2"
+                    ],
+                    "shards": [
+                        {
+                            "name": "shard 1",
+                            "hostname": "shard1_host",
+                            "port": "11111",
+                            "out_file": "tests/utils/log_files/model_1.out",
+                            "err_file": "tests/utils/log_files/model_1.err",
+                            "conf_file": "/path/to/conf_file",
+                            "telemetry_metadata": {
+                                "status_dir": "tests/utils/status_files/model_3",
+                                "job_id": "111",
+                                "step_id": "111"
+                            }
+                        
+                        },
+                        {
+                            "name": "shard 2",
+                            "hostname": "shard2_host",
+                            "port": "11111",
+                            "out_file": "tests/utils/log_files/model_0.out",
+                            "err_file": "tests/utils/log_files/model_0.err",
+                            "conf_file": "/path/to/conf_file",
+                            "telemetry_metadata": {
+                                "status_dir": "tests/utils/status_files/model_1",
+                                "job_id": "111",
+                                "step_id": "111"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "ensemble": [
+                {
+                    "name": "ensemble_1",
+                    "perm_strat": "string0",
+                    "batch_settings": {
+                        "string": "Any0"
+                    },
+                    "params": {
+                        "string": [
+                            "Any1",
+                            "Any3"
+                        ]
+                    },
+                    "models": [
+                        {
+                            "name": "ensemble_1_member_1",
+                            "path": "string",
+                            "exe_args": [
+                                "string"
+                            ],
+                            "batch_settings": {
+                                "batch_cmd": "command",
+                                "batch_args": {
+                                    "arg1": "string1",
+                                    "arg2": null
+                                }
+                            },
+                            "run_settings": {
+                                "exe": "echo",
+                                "run_command": "srun",
+                                "run_args": {
+                                    "arg1": "string1",
+                                    "arg2": null
+                                }
+                            },
+                            "params": {
+                                "string": "Any"
+                            },
+                            "files": {
+                                "Symlink": [
+                                    "file1",
+                                    "file2"
+                                ],
+                                "Configure": [
+                                    "file3"
+                                ],
+                                "Copy": [
+                                    "file4",
+                                    "file5"
+                                ]
+                            },
+                            "colocated_db": {
+                                "settings": {
+                                    "protocol": "TCP/IP",
+                                    "port": 1111,
+                                    "interface": "lo",
+                                    "db_cpus": 1,
+                                    "limit_app_cpus": "True",
+                                    "debug": "False"
+                                },
+                                "scripts": [
+                                    {
+                                        "script1": {
+                                            "backend": "script1_torch",
+                                            "device": "script1_cpu"
+                                        }
+                                    },
+                                    {
+                                        "script2": {
+                                            "backend": "script2_torch",
+                                            "device": "script2_gpu"
+                                        }
+                                    }
+                                ],
+                                "models": [
+                                    {
+                                        "model1": {
+                                            "backend": "model1_tf",
+                                            "device": "model1_cpu"
+                                        }
+                                    },
+                                    {
+                                        "model2": {
+                                            "backend": "model2_tf",
+                                            "device": "model2_cpu"
+                                        }
+                                    }
+                                ]
+                            },
+                            "telemetry_metadata": {
+                                "status_dir": "tests/utils/status_files/model_0",
+                                "job_id": "111",
+                                "step_id": "111"
+                            },
+                            "out_file": "tests/utils/log_files/model_0.out",
+                            "err_file": "tests/utils/log_files/model_0.err"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/utils/manifest_files/JSONDecodererror.json
+++ b/tests/utils/manifest_files/JSONDecodererror.json
@@ -1,7 +1,7 @@
 
     "schema info" : {
         "schema_name" : "entity manifest",
-        "version" : "0.0.3"
+        "version" : "0.0.4"
     },
     "experiment" : {},
     "runs": []

--- a/tests/utils/manifest_files/exp_telem_disabled_manifest.json
+++ b/tests/utils/manifest_files/exp_telem_disabled_manifest.json
@@ -1,7 +1,7 @@
 {
     "schema info": {
         "schema_name": "entity manifest",
-        "version": "0.0.3"
+        "version": "0.0.4"
     },
     "experiment": {
         "name": "my-experiment",

--- a/tests/utils/manifest_files/fauxexp/.smartsim/telemetry/manifest.json
+++ b/tests/utils/manifest_files/fauxexp/.smartsim/telemetry/manifest.json
@@ -1,7 +1,7 @@
 {
     "schema info": {
         "schema_name": "entity manifest",
-        "version": "0.0.3"
+        "version": "0.0.4"
     },
     "experiment": {
         "name": "my-experiment",

--- a/tests/utils/manifest_files/malformed_apps.json
+++ b/tests/utils/manifest_files/malformed_apps.json
@@ -1,7 +1,7 @@
 {
     "schema info": {
         "schema_name": "entity manifest",
-        "version": "0.0.3"
+        "version": "0.0.4"
     },
     "experiment": {
         "name": "my-experiment",

--- a/tests/utils/manifest_files/malformed_ensembles.json
+++ b/tests/utils/manifest_files/malformed_ensembles.json
@@ -1,7 +1,7 @@
 {
     "schema info": {
         "schema_name": "entity manifest",
-        "version": "0.0.3"
+        "version": "0.0.4"
     },
     "experiment": {
         "name": "my-experiment",

--- a/tests/utils/manifest_files/malformed_orcs.json
+++ b/tests/utils/manifest_files/malformed_orcs.json
@@ -1,7 +1,7 @@
 {
     "schema info": {
         "schema_name": "entity manifest",
-        "version": "0.0.3"
+        "version": "0.0.4"
     },
     "experiment": {
         "name": "my-experiment",

--- a/tests/utils/manifest_files/manifesttest.json
+++ b/tests/utils/manifest_files/manifesttest.json
@@ -1,7 +1,7 @@
 {
     "schema info": {
         "schema_name": "entity manifest",
-        "version": "0.0.3"
+        "version": "0.0.4"
     },
     "experiment": {
         "name": "my-experiment",

--- a/tests/utils/manifest_files/no_apps_manifest.json
+++ b/tests/utils/manifest_files/no_apps_manifest.json
@@ -1,7 +1,7 @@
 {
     "schema info": {
         "schema_name": "entity manifest",
-        "version": "0.0.3"
+        "version": "0.0.4"
     },
     "experiment": {
         "name": "my-experiment",

--- a/tests/utils/manifest_files/no_ensembles_manifest.json
+++ b/tests/utils/manifest_files/no_ensembles_manifest.json
@@ -1,7 +1,7 @@
 {
     "schema info": {
         "schema_name": "entity manifest",
-        "version": "0.0.3"
+        "version": "0.0.4"
     },
     "experiment": {
         "name": "my-experiment",

--- a/tests/utils/manifest_files/no_experiment_manifest.json
+++ b/tests/utils/manifest_files/no_experiment_manifest.json
@@ -1,7 +1,7 @@
 {
     "schema info" : {
         "schema_name" : "entity manifest",
-        "version" : "0.0.3"
+        "version" : "0.0.4"
     },
     "experiment" : {},
     "runs": []

--- a/tests/utils/manifest_files/no_orchestrator_manifest.json
+++ b/tests/utils/manifest_files/no_orchestrator_manifest.json
@@ -1,7 +1,7 @@
 {
     "schema info": {
         "schema_name": "entity manifest",
-        "version": "0.0.3"
+        "version": "0.0.4"
     },
     "experiment": {
         "name": "my-experiment",

--- a/tests/utils/manifest_files/no_running.json
+++ b/tests/utils/manifest_files/no_running.json
@@ -1,7 +1,7 @@
 {
     "schema info": {
         "schema_name": "entity manifest",
-        "version": "0.0.3"
+        "version": "0.0.4"
     },
     "experiment": {
         "name": "my-experiment",


### PR DESCRIPTION
This PR updates SmartDashboard to version 0.0.4 and also updates the version of the `manifest.json` files it accepts. I also snuck in the fix for disallowing Streamlit version 1.31.X because it breaks the multipage behavior of the dashboard. I added a `0.0.3_manifest.json` to ensure that 0.0.3 manifests still work as they should.