### PR TITLE
Decrease pinned pydantic version

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -6,6 +6,7 @@ Development branch
 
 Description
 
+- Decrease the pinned version of Pydantic (SmartDashboard-PR51_) 
 - Bump version to 0.0.4, exclude streamlit version 1.31.X (SmartDashboard-PR50_)
 - Drop Python 3.8 support, add 3.11 support. (SmartDashboard-PR49_)
 - Add Database Telemetry page. (SmartDashboard-PR38_)
@@ -13,6 +14,7 @@ Description
   on pull requests into develop. (SmartDashboard-PR47_)
 - Add manifest file tracking. (SmartDashboard-PR46_)
 
+.. _SmartDashboard-PR51: https://github.com/CrayLabs/SmartDashboard/pull/51
 .. _SmartDashboard-PR50: https://github.com/CrayLabs/SmartDashboard/pull/50
 .. _SmartDashboard-PR49: https://github.com/CrayLabs/SmartDashboard/pull/49
 .. _SmartDashboard-PR38: https://github.com/CrayLabs/SmartDashboard/pull/38

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ readme = "README.md"
 dependencies = [
     "altair>=5.2.0",
     "pandas>=2.0.0",
-    "pydantic>=2.5.2",
+    "pydantic>=1.10.14",
     "streamlit>=1.28.0, !=1.31.0, !=1.31.1",
     "watchdog>=3.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ readme = "README.md"
 dependencies = [
     "altair>=5.2.0",
     "pandas>=2.0.0",
-    "pydantic>=1.10.14, <2",
+    "pydantic>=1.10.14, <2", # this is pinned to keep consistency with SmartSim
     "streamlit>=1.28.0, !=1.31.0, !=1.31.1",
     "watchdog>=3.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ readme = "README.md"
 dependencies = [
     "altair>=5.2.0",
     "pandas>=2.0.0",
-    "pydantic>=1.10.14",
+    "pydantic>=1.10.14, <2",
     "streamlit>=1.28.0, !=1.31.0, !=1.31.1",
     "watchdog>=3.0.0",
 ]

--- a/smartdashboard/schemas/orchestrator.py
+++ b/smartdashboard/schemas/orchestrator.py
@@ -26,7 +26,7 @@
 
 import typing as t
 
-from pydantic import field_validator
+from pydantic import validator
 
 from smartdashboard.schemas.base import HasName
 from smartdashboard.schemas.shard import Shard
@@ -37,7 +37,7 @@ class Orchestrator(HasName):
     interface: t.List[str] = []
     shards: t.List[Shard] = []
 
-    @field_validator("interface", mode="before")
+    @validator("interface", pre=True)
     @classmethod
     def convert_interface(cls, value: t.Union[str, t.List[str]]) -> t.List[str]:
         if isinstance(value, str):

--- a/smartdashboard/view_builders.py
+++ b/smartdashboard/view_builders.py
@@ -151,14 +151,14 @@ def app_builder(manifest: Manifest) -> ApplicationView:
             column=col1,
             title="Batch Settings",
             dict_name="batch_settings",
-            entity=selected_application.model_dump() if selected_application else {},
+            entity=selected_application.dict() if selected_application else {},
             df_columns=["Name", "Value"],
         )
         build_dataframe_generic(
             column=col2,
             title="Run Settings",
             dict_name="run_settings",
-            entity=selected_application.model_dump() if selected_application else {},
+            entity=selected_application.dict() if selected_application else {},
             df_columns=["Name", "Value"],
         )
 
@@ -169,14 +169,14 @@ def app_builder(manifest: Manifest) -> ApplicationView:
             column=col1,
             title="Parameters",
             dict_name="params",
-            entity=selected_application.model_dump() if selected_application else {},
+            entity=selected_application.dict() if selected_application else {},
             df_columns=["Name", "Value"],
         )
         build_dataframe_generic(
             column=col2,
             title="Files",
             dict_name="files",
-            entity=selected_application.model_dump() if selected_application else {},
+            entity=selected_application.dict() if selected_application else {},
             df_columns=["Type", "File"],
         )
 
@@ -311,7 +311,7 @@ def ens_builder(manifest: Manifest) -> EnsembleView:
     with st.expander(label="Batch Settings"):
         batch = flatten_nested_keyvalue_containers(
             "batch_settings",
-            selected_ensemble.model_dump() if selected_ensemble else {},
+            selected_ensemble.dict() if selected_ensemble else {},
         )
         render_dataframe(pd.DataFrame(batch, columns=["Name", "Value"]))
 
@@ -349,14 +349,14 @@ def ens_builder(manifest: Manifest) -> EnsembleView:
             column=col1,
             title="Batch Settings",
             dict_name="batch_settings",
-            entity=member.model_dump() if member else {},
+            entity=member.dict() if member else {},
             df_columns=["Name", "Value"],
         )
         build_dataframe_generic(
             column=col2,
             title="Run Settings",
             dict_name="run_settings",
-            entity=member.model_dump() if member else {},
+            entity=member.dict() if member else {},
             df_columns=["Name", "Value"],
         )
 
@@ -367,14 +367,14 @@ def ens_builder(manifest: Manifest) -> EnsembleView:
             column=col1,
             title="Parameters",
             dict_name="params",
-            entity=member.model_dump() if member else {},
+            entity=member.dict() if member else {},
             df_columns=["Name", "Value"],
         )
         build_dataframe_generic(
             column=col2,
             title="Files",
             dict_name="files",
-            entity=member.model_dump() if member else {},
+            entity=member.dict() if member else {},
             df_columns=["Type", "File"],
         )
 

--- a/tests/test_helpers/test_format_mixed_nested_dict.py
+++ b/tests/test_helpers/test_format_mixed_nested_dict.py
@@ -36,12 +36,12 @@ from ..utils.test_entities import *
     [
         pytest.param(
             "batch_settings",
-            application_1.model_dump(),
+            application_1.dict(),
             [("batch_cmd", "command"), ("arg1", "string1"), ("arg2", "None")],
         ),
         pytest.param(
             "run_settings",
-            application_1.model_dump(),
+            application_1.dict(),
             [
                 ("exe", "echo"),
                 ("run_command", "srun"),
@@ -49,10 +49,10 @@ from ..utils.test_entities import *
                 ("arg2", "None"),
             ],
         ),
-        pytest.param("params", ensemble_1.models[0].model_dump(), [("string", "Any")]),
+        pytest.param("params", ensemble_1.models[0].dict(), [("string", "Any")]),
         pytest.param(
             "files",
-            application_2.model_dump(),
+            application_2.dict(),
             [
                 ("Symlink", "file1"),
                 ("Symlink", "file2"),
@@ -73,7 +73,7 @@ from ..utils.test_entities import *
                 ("debug", "False"),
             ],
         ),
-        pytest.param("doesnt_exist", ensemble_1.models[0].model_dump(), []),
+        pytest.param("doesnt_exist", ensemble_1.models[0].dict(), []),
         pytest.param("batch_settings", None, []),
     ],
 )


### PR DESCRIPTION
This PR is decreases the pinned pydantic version from `"pydantic>=2.5.2"` to `"pydantic>=1.10.14"` to remain compatible with the other repos. `model_dump()` was changed to `dict()`, which is deprecated and will be removed by pydantic v3. `field_validator` was changed to `validator`, and is also deprecated and scheduled to be removed by v3 of pydantic.