### PR TITLE
Correct header styling

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Development branch
+### Development branch
 
 Description
 
@@ -24,7 +24,7 @@ Description
 -   Add manifest file tracking.
     ([SmartDashboard-PR46](https://github.com/CrayLabs/SmartDashboard/pull/46))
 
-## 0.0.3
+### 0.0.3
 
 Released on 15 February 2024
 
@@ -35,7 +35,7 @@ Description
 -   Added experiment level logs to the dashboard.
     ([SmartDashboard-PR37](https://github.com/CrayLabs/SmartDashboard/pull/37))
 
-## 0.0.2
+### 0.0.2
 
 Released on 14 December 2023
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -4,6 +4,8 @@
 
 Description
 
+-   Fix header styling issue
+    ([SmartDashboard-PR55](https://github.com/CrayLabs/SmartDashboard/pull/55))
 -   Automate the creation of release notes
     ([SmartDashboard-PR54](https://github.com/CrayLabs/SmartDashboard/pull/54))
 -   Add database telemetry documentation.


### PR DESCRIPTION
When converting from rst to md, headers were sized larger than needed. In this PR I am changing headers from ## to ### to correct the styling issues in readthedocs.